### PR TITLE
Add Fly Machines proxy config and Prisma push option

### DIFF
--- a/litellm/deploy/fly/proxy_config.yaml
+++ b/litellm/deploy/fly/proxy_config.yaml
@@ -1,0 +1,41 @@
+# PocketData LiteLLM proxy configuration for Fly Machines
+# This minimal config bootstraps a single OpenAI model, enables DB-backed state,
+# and wires up the MCP gateway to the forthcoming personal search service.
+model_list:
+  - model_name: gpt-oss-20b
+    litellm_params:
+      model: openai/gpt-oss-20b:free
+      api_key: os.environ/OPENROUTER_API_KEY
+      timeout: 90
+      metadata:
+        site_url: os.environ/OR_SITE_URL
+        app_name: os.environ/OR_APP_NAME
+    model_info:
+      mode: chat
+    model_info:
+      mode: chat
+
+litellm_settings:
+  telemetry: true
+  drop_params: true
+  json_logs: true
+  mcp_aliases:
+    search: personal_search
+
+mcp_servers:
+  personal_search:
+    # Replace this URL once the search MCP service is deployed.
+    url: http://pocketsearch.internal/mcp
+    transport: http
+    auth_type: authorization
+    auth_value: os.environ/PERSONAL_SEARCH_MCP_AUTH
+    mcp_info:
+      description: Personal browsing search MCP service reachable on Fly's private network.
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+  database_url: os.environ/DATABASE_URL
+  store_model_in_db: false
+  allow_requests_on_db_unavailable: true
+  completion_model: gpt-oss-20b
+  ui_access_mode: authenticated

--- a/litellm/fly.toml
+++ b/litellm/fly.toml
@@ -1,0 +1,19 @@
+cmd = [
+  "--config",
+  "/app/deploy/fly/proxy_config.yaml",
+  "--port",
+  "4000",
+  "--use_prisma_db_push"
+]
+
+[env]
+  PORT = "4000"
+  HOST = "0.0.0.0"
+  LITELLM_MODE = "PRODUCTION"
+  PYTHONUNBUFFERED = "1"
+  OR_SITE_URL = "https://pocketlitellm.fly.dev"
+  OR_APP_NAME = "PocketData LiteLLM"
+  CONFIG_FILE_PATH = "/app/deploy/fly/proxy_config.yaml"
+
+[[services]]
+  protocol = 'tcp'


### PR DESCRIPTION
## Summary
- add Fly Machines proxy configuration tailored for the PocketData LiteLLM deployment, including OpenRouter credentials and MCP settings
- enable Prisma schema push during Fly startup and surface the config file path via environment variables

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4f38b8494832c8d381b22e408cd93